### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and Strin…

### DIFF
--- a/kiteq-commons/src/main/java/org/kiteq/commons/util/ByteArrayUtils.java
+++ b/kiteq-commons/src/main/java/org/kiteq/commons/util/ByteArrayUtils.java
@@ -14,7 +14,7 @@ public class ByteArrayUtils {
             return null;
         }
         
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         
         for (byte b : bytes) {
             sb.append(getHexString(b)).append(' ');
@@ -28,8 +28,8 @@ public class ByteArrayUtils {
         if (bytes == null) {
             return null;
         }
-        
-        StringBuffer sb = new StringBuffer();
+
+        StringBuilder sb = new StringBuilder();
         
         for (byte b : bytes) {
             if (b > 31 && b < 127 || b == 10 || b == 13) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1149

Please let me know if you have any questions.

M-Ezzat